### PR TITLE
Refactor Google Analytics integration in Sphinx configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -134,6 +134,3 @@ if os.getenv("GITHUB_ACTIONS"):
         extensions.append("sphinxcontrib.googleanalytics")
     googleanalytics_id = os.getenv("GOOGLE_ANALYTICS_ID", "G-XXXXX")
 
-if "sphinxcontrib.googleanalytics" not in extensions:
-    extensions.append("sphinxcontrib.googleanalytics")
-googleanalytics_id = os.getenv("GOOGLE_ANALYTICS_ID", "G-XXXXX")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,8 +129,11 @@ if 'sphinx_sitemap' in extensions:
     sitemap_locales = [None]
     sitemap_url_scheme = "{link}"
 
-if os.getenv("GITHUB_ACTIONS") and os.getenv("GOOGLE_ANALYTICS_ID"):
-    googleanalytics_id = os.getenv("GOOGLE_ANALYTICS_ID")
-    if googleanalytics_id and googleanalytics_id.startswith("G-") and len(googleanalytics_id) > 4:
-        if "sphinxcontrib.googleanalytics" not in extensions:
-            extensions.append("sphinxcontrib.googleanalytics")
+if os.getenv("GITHUB_ACTIONS"):
+    if "sphinxcontrib.googleanalytics" not in extensions:
+        extensions.append("sphinxcontrib.googleanalytics")
+    googleanalytics_id = os.getenv("GOOGLE_ANALYTICS_ID", "G-XXXXX")
+
+if "sphinxcontrib.googleanalytics" not in extensions:
+    extensions.append("sphinxcontrib.googleanalytics")
+googleanalytics_id = os.getenv("GOOGLE_ANALYTICS_ID", "G-XXXXX")


### PR DESCRIPTION
Streamline the Google Analytics integration by removing redundant configuration and ensuring the extension is only added when necessary. Default to a placeholder ID if the environment variable is not set.