### PR TITLE
Add GOOGLE_ANALYTICS_ID to Sphinx build step

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -55,6 +55,8 @@ jobs:
       - name: Run Sphinx build for html
         run: |
           sphinx-build -b html docs build/html
+        env:
+          GOOGLE_ANALYTICS_ID: ${{ vars.GOOGLE_ANALYTICS_ID }} 
 
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           sphinx-build -b html docs build/html
         env:
-          GOOGLE_ANALYTICS_ID: ${{ vars.GOOGLE_ANALYTICS_ID }} 
+          GOOGLE_ANALYTICS_ID: ${{ vars.GOOGLE_ANALYTICS_ID }}
 
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Introduce the GOOGLE_ANALYTICS_ID environment variable to the Sphinx build process for enhanced tracking capabilities.