### PR TITLE
Modify allow-licenses in dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -36,4 +36,4 @@ jobs:
         # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
         with:
           comment-summary-in-pr: always
-          deny-licenses: GPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.1-or-later, MIT, MPL-2.0, CC-BY-4.0, CC-SA-BY-4.0, Apache-2.0
+          allow-licenses: GPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.1-or-later, MIT, MPL-2.0, CC-BY-4.0, CC-BY-SA-4.0, Apache-2.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,39 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable
+# packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+---
+name: 'Dependency review'
+on:
+  pull_request:
+    branches: [ "master" ]
+
+# If using a dependency submission action in this workflow this permission will need to be set to:
+#
+# permissions:
+#   contents: write
+#
+# https://docs.github.com/en/enterprise-cloud@latest/code-security/supply-chain-security/understanding-your-software-supply-chain/using-the-dependency-submission-api
+permissions:
+  contents: read
+  # Write permissions for pull-requests are required for using the `comment-summary-in-pr` option, comment out if you aren't using this option
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v4
+
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v4
+        # Commonly enabled options, see https://github.com/actions/dependency-review-action#configuration-options for all available options.
+        with:
+          comment-summary-in-pr: always
+          deny-licenses: GPL-2.0-or-later, LGPL-2.1-or-later, GFDL-1.1-or-later, MIT, MPL-2.0, CC-BY-4.0, CC-SA-BY-4.0, Apache-2.0


### PR DESCRIPTION
Updated the allow-licenses option to include multiple licenses.